### PR TITLE
docs: fix smtpServerPort option

### DIFF
--- a/docs/contributor/send.rst
+++ b/docs/contributor/send.rst
@@ -130,7 +130,7 @@ servers will only need the following settings::
 
     [sendemail]
        smtpServer = smtp.example.org
-       smtpPort = 465
+       smtpServerPort = 465
        smtpEncryption = ssl
        smtpUser = alice.developer@example.org
        smtpPass = [omitted]


### PR DESCRIPTION
The right name includes a "Server".

Link: https://git-scm.com/docs/git-send-email#Documentation/git-send-email.txt---smtp-server-portltportgt