### PR TITLE
Fixes the subject prefix in the emails

### DIFF
--- a/b4/__init__.py
+++ b/b4/__init__.py
@@ -122,7 +122,7 @@ DEFAULT_CONFIG = {
     'thanks-pr-template': None,
     # See thanks-am-template.example
     'thanks-am-template': None,
-    # If this is not set, we'll use what we find in 
+    # If this is not set, we'll use what we find in
     # git-config for gpg.program, and if that's not set,
     # we'll use "gpg" and hope for the better
     'gpgbin': None,
@@ -2133,17 +2133,25 @@ class LoreSubject:
 
     def get_rebuilt_subject(self, eprefixes: Optional[List[str]] = None):
         _pfx = self.get_extra_prefixes()
+        version = ''
+        expected = ''
         if eprefixes:
             for _epfx in eprefixes:
                 if _epfx not in _pfx:
                     _pfx.append(_epfx)
-        if self.revision > 1:
-            _pfx.append(f'v{self.revision}')
-        if self.expected > 1:
-            _pfx.append('%s/%s' % (str(self.counter).zfill(len(str(self.expected))), self.expected))
 
-        if len(_pfx):
-            return '[PATCH ' + ' '.join(_pfx) + '] ' + self.subject
+        if len(_pfx) > 0:
+            # This is added to handle the extra space after
+            # subject prefixes
+            _pfx.append('')
+
+        if self.revision > 1:
+            version = f' v{self.revision}'
+        if self.expected > 1:
+            expected = ' %s/%s' % (str(self.counter).zfill(len(str(self.expected))), self.expected)
+
+        if len(_pfx) or len(version) or len(expected):
+            return '[' + ' '.join(_pfx) + 'PATCH' + version + expected + '] ' + self.subject
         else:
             return f'[PATCH] {self.subject}'
 


### PR DESCRIPTION
The subject prefix had been coming "after" the "[PATCH", fix that to come before the PATCH string. Closes #3 