### PR TITLE
mbox: remove "try: ... except: sys.exit(1)" wrapper in make_am()

### DIFF
--- a/b4/mbox.py
+++ b/b4/mbox.py
@@ -103,14 +103,10 @@ def make_am(msgs: List[email.message.Message], cmdargs: argparse.Namespace, msgi
     else:
         cherrypick = None
 
-    try:
-        am_msgs = lser.get_am_ready(noaddtrailers=cmdargs.noaddtrailers,
-                                    covertrailers=covertrailers, addmysob=cmdargs.addmysob,
-                                    addlink=cmdargs.addlink, cherrypick=cherrypick,
-                                    copyccs=cmdargs.copyccs, allowbadchars=cmdargs.allowbadchars)
-    except KeyError:
-        sys.exit(1)
-
+    am_msgs = lser.get_am_ready(noaddtrailers=cmdargs.noaddtrailers,
+                                covertrailers=covertrailers, addmysob=cmdargs.addmysob,
+                                addlink=cmdargs.addlink, cherrypick=cherrypick,
+                                copyccs=cmdargs.copyccs, allowbadchars=cmdargs.allowbadchars)
     logger.info('---')
 
     if cherrypick is None:


### PR DESCRIPTION
The `try: ... except: sys.exit(1)` mapper results in b4 exiting without any error message for a very broad range of exceptions. This is in general less helpful than an exception backtrace.

This came up when trying to use b4 without `user.name` and `user.email` entries in the git config and using `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` environment variables instead, because `LoreTrailer.__init__()` accesses the config keys without checking for their existence or falling back to the envrionment variables.

While `LoreTrailer.__init__()` should likely be changed as well to print an error if name or email are unconfigured and should also likely use the environment variables, this tackles the low hanging fruit first and makes finding the issue easier by printing a backtrace in this case.