### PR TITLE
Add Based-on: to the utility trailer list

### DIFF
--- a/src/b4/__init__.py
+++ b/src/b4/__init__.py
@@ -1051,7 +1051,7 @@ class LoreTrailer:
     lmsg = None
     # Small list of recognized utility trailers
     _utility: Set[str] = {'fixes', 'link', 'buglink', 'closes', 'obsoleted-by', 'message-id', 'change-id',
-                          'base-commit'}
+                          'base-commit', 'based-on'}
 
     def __init__(self, name: Optional[str] = None, value: Optional[str] = None, extinfo: Optional[str] = None,
                  msg: Optional[email.message.Message] = None):


### PR DESCRIPTION
Based-on: is a trailer that holds Message-Id of a patch series dependency. It is recognized by Patchew and used for QEMU development, which is documented at:
https://qemu.readthedocs.io/en/v9.0.0/devel/submitting-a-patch.html#base-patches-against-current-git-master

Add Based-on: to the utility trailer list so that Message-Ids Based-on: tags carry won't be confused as email addresses.