### PR TITLE
mbox: create outdir by default when it not exists

### DIFF
--- a/src/b4/mbox.py
+++ b/src/b4/mbox.py
@@ -223,6 +223,9 @@ def make_am(msgs: List[email.message.Message], cmdargs: argparse.Namespace, msgi
             slug = lser.get_slug(extended=True)
 
         if outdir != '-':
+            if not os.path.exists(outdir):
+                os.makedirs(outdir)
+
             am_filename = os.path.join(outdir, f'{slug}.{dftext}')
             am_cover = os.path.join(outdir, f'{slug}.cover')
 


### PR DESCRIPTION
When using b4 with `b4 am "xxx" -o /home/lkml/`, it failed with "No such file or directory". So create outdir by default when it not exists.