### PR TITLE
pr: regex support tag with + character

### DIFF
--- a/src/b4/pr.py
+++ b/src/b4/pr.py
@@ -38,7 +38,8 @@ PULL_BODY_WITH_COMMIT_ID_RE = [
 
 # I don't like these
 PULL_BODY_REMOTE_REF_RE = [
-    re.compile(r'^\s*([\w+-]+(?:://|@)[\w/.@:~-]+)[\s\\]+([\w/._-]+)\s*$', re.M | re.I),
+    # match string like: "https://git.kernel.org/pub/scm/linux/kernel/git/conor/linux.git/ riscv-dt-fixes-for-v6.10-rc5+"
+    re.compile(r'^\s*([\w+-]+(?:://|@)[\w/.@:~-]+)[\s\\]+([\w/._+-]+)\s*$', re.M | re.I),
     re.compile(r'^\s*([\w+-]+(?:://|@)[\w/.@~-]+)\s*$', re.M | re.I),
 ]
 


### PR DESCRIPTION
Conor Dooley reported that `b4 pr 20240627-wobbly-custody-5df564133088@spud` failed, the root cause is reporef_re matches failed when there is extra + sign, though it is not recommend to have special characters in tag name, but git accepts this and we better fix it.

Link: https://bugzilla.kernel.org/show_bug.cgi?id=218995