### PR TITLE
change the manpage section from 5 to 1

### DIFF
--- a/src/b4/man/b4.1
+++ b/src/b4/man/b4.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "B4" 5 "2024-06-10" "0.14-dev"
+.TH "B4" "1" "2024-06-10" "0.14-dev"
 .SH NAME
 B4 \- Work with code submissions in a public-inbox archive
 .SH SYNOPSIS
@@ -43,7 +43,7 @@ like those used in the Linux kernel development.
 The name \(dqb4\(dq was chosen for ease of typing and because B\-4 was the
 precursor to Lore and Data in the Star Trek universe.
 .sp
-Full documentation is available on \fI\%https://b4.docs.kernel.org/\fP\&.
+Full documentation is available on  <https://b4.docs.kernel.org/> \&.
 .SH SUBCOMMANDS
 .sp
 Maintainer\-oriented:
@@ -285,7 +285,7 @@ These commands allow preparing and submitting a patch series for review
 on the mailing list. Full documentation is available online at the
 following address:
 .sp
-\fI\%https://b4.docs.kernel.org/en/latest/contributor/overview.html\fP
+ <https://b4.docs.kernel.org/en/latest/contributor/overview.html> 
 .sp
 For options, see the output of \fBb4 prep \-\-help\fP, \fBb4 trailers
 \-\-help\fP and \fBb4 send \-\-help\fP\&.
@@ -330,16 +330,16 @@ either the toplevel \fB$HOME/.gitconfig\fP file, or in a per\-repository
 \&.git/config file if your workflow changes per project.
 .sp
 To see configuration options available, see online documentation at
-\fI\%https://b4.docs.kernel.org/en/latest/config.html\fP
+ <https://b4.docs.kernel.org/en/latest/config.html> 
 .SH PROXYING REQUESTS
 .sp
 Commands making remote HTTP requests may be configured to use a proxy by
 setting the \fBHTTPS_PROXY\fP environment variable, as described in
-\fI\%https://docs.python\-requests.org/en/latest/user/advanced/#proxies\fP\&.
+ <https://docs.python\-requests.org/en/latest/user/advanced/#proxies> \&.
 .SH SUPPORT
 .sp
-Please email \fI\%tools@kernel.org\fP with support requests, or browse the list
-archive at \fI\%https://lore.kernel.org/tools\fP\&.
+Please email  <tools@kernel.org>  with support requests, or browse the list
+archive at  <https://lore.kernel.org/tools> \&.
 .SH AUTHOR
 mricon@kernel.org
 

--- a/src/b4/man/b4.1.rst
+++ b/src/b4/man/b4.1.rst
@@ -9,7 +9,7 @@ Work with code submissions in a public-inbox archive
 :Copyright: The Linux Foundation and contributors
 :License:   GPLv2+
 :Version:   0.14-dev
-:Manual section: 5
+:Manual section: 1
 
 SYNOPSIS
 --------


### PR DESCRIPTION
Manpages in category 5 are according to 'man man' docs for "File formats
and conventions, e.g. /etc/passwd", which does not fit the contents of
the manpage in question. Instead move it to section 1, which contains
docs for "Executable programs or shell commands".

Since this also requires a small code change in the docs themselves also
regenerate the rendered version of the manpage.
