### PR TITLE
Extend checkpatch.pl compatibilities

### DIFF
--- a/src/b4/ez.py
+++ b/src/b4/ez.py
@@ -1674,7 +1674,17 @@ def get_check_cmds() -> Tuple[List[str], List[str]]:
         if topdir:
             checkpatch = os.path.join(topdir, 'scripts', 'checkpatch.pl')
             if os.access(checkpatch, os.X_OK):
-                ppcmds = [f'{checkpatch} -q --terse --no-summary --mailback --showfile']
+                ecode, help_out, err = b4._run_command([checkpatch, "-h"], stdin=None, rundir=topdir)
+                help_out = help_out.decode(errors='replace').strip() if help_out else ""
+                if ecode == 0:
+                    ppcmds = f'{checkpatch}'
+                    for arg in ["q", "-terse", "-no-summary", "-mailback", "-showfile"]:
+                        if ("-" + arg + " ") in help_out:
+                            ppcmds += " " + "-" + arg
+                    ppcmds += " -"
+                    ppcmds = [ppcmds]
+                else:
+                    ppcmds = [f'{checkpatch} -q --terse --no-summary --mailback --showfile -']
 
     # TODO: support for a whole-series check command, (pytest, etc)
     return ppcmds, scmds

--- a/src/b4/ez.py
+++ b/src/b4/ez.py
@@ -1666,6 +1666,8 @@ def get_check_cmds() -> Tuple[List[str], List[str]]:
     scmds = list()
     if config.get('prep-perpatch-check-cmd'):
         ppcmds = config.get('prep-perpatch-check-cmd')
+        if isinstance(ppcmds, str):
+            ppcmds = [ppcmds]
     else:
         # Use recommended checkpatch defaults if we find checkpatch
         topdir = b4.git_get_toplevel()


### PR DESCRIPTION
Note: on tools list: <https://lore.kernel.org/tools/20240815-extend-checkpatch-v1-0-ab7f654be699@linaro.org/>


This series fixes an error from reading prep-perpatch-check-cmd from
.b4-config inappropriately, and also allows b4 to be more gentle for
projects which use checkpatch.pl but are not the kernel.

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>