### PR TITLE
Add Supersedes: to the utility trailer list

### DIFF
--- a/src/b4/__init__.py
+++ b/src/b4/__init__.py
@@ -1786,6 +1786,7 @@ class LoreMessage:
                     'subscribe',
                     'unsubscribe',
                     'base-commit',
+                    'based-on',
                     'supersedes',
                     'change-id',
                     'message-id',

--- a/src/b4/__init__.py
+++ b/src/b4/__init__.py
@@ -1461,6 +1461,7 @@ class LoreTrailer:
         'change-id',
         'base-commit',
         'based-on',
+        'supersedes',
     }
 
     def __init__(
@@ -1785,6 +1786,7 @@ class LoreMessage:
                     'subscribe',
                     'unsubscribe',
                     'base-commit',
+                    'supersedes',
                     'change-id',
                     'message-id',
                 }


### PR DESCRIPTION
Supersedes: is a trailer that holds Message-Id of a superseded patch series and recognized by Patchew:
https://github.com/patchew-project/patchew/commit/5a7fd9e9996fb36c4d564098cce33fff24bbd89a