### PR TITLE
ez: introduce --in-reply-to for send

### DIFF
--- a/src/b4/command.py
+++ b/src/b4/command.py
@@ -378,6 +378,8 @@ def setup_parser() -> argparse.ArgumentParser:
                          help='Do not add any addresses found in the cover or patch trailers to To: or Cc:')
     sp_send.add_argument('--to', nargs='+', metavar='ADDR', help='Addresses to add to the To: list')
     sp_send.add_argument('--cc', nargs='+', metavar='ADDR', help='Addresses to add to the Cc: list')
+    sp_send.add_argument('--in-reply-to', metavar='IDENTIFIER',
+                         help='Send patchset in reply to a message')
     sp_send.add_argument('--not-me-too', action='store_true', default=False,
                          help='Remove yourself from the To: or Cc: list')
     sp_send.add_argument('--resend', metavar='vN', nargs='?', const='latest',

--- a/src/b4/ez.py
+++ b/src/b4/ez.py
@@ -1804,6 +1804,9 @@ def cmd_send(cmdargs: argparse.Namespace) -> None:
 
         logger.info('Converted the branch to %s messages', len(patches))
 
+    if cmdargs.in_reply_to:
+        patches[0][1].add_header('In-Reply-To', '<%s>' % cmdargs.in_reply_to)
+
     usercfg = b4.get_user_config()
     myemail = usercfg.get('email')
 


### PR DESCRIPTION
When sending numerous patchsets touching multiple projects, the structure of the email thread could be top-level cover letter with patchsets as subthreads (replies). As an example, while developing a filesystem feature one can also develop tests for xfstests for that feature.

With --in-reply-to one can send top-level cover and use it as base for sending other b4 managed branches.

This patch introduces 'b4 --in-reply-to IDENTIFIER' for adding 'In-Reply-To:' header to cover-letter message.