### PR TITLE
prep --check: Add support to spellcheck is codespell is installed

### DIFF
--- a/src/b4/ez.py
+++ b/src/b4/ez.py
@@ -43,6 +43,12 @@ try:
 except ModuleNotFoundError:
     can_gfr = False
 
+try:
+    import codespell_lib
+    can_codespell = True
+except ModuleNotFoundError:
+    can_codespell = False
+
 logger = b4.logger
 
 MAGIC_MARKER = '--- b4-submit-tracking ---'
@@ -1808,7 +1814,8 @@ def get_check_cmds() -> Tuple[List[str], List[str]]:
         if topdir:
             checkpatch = os.path.join(topdir, 'scripts', 'checkpatch.pl')
             if os.access(checkpatch, os.X_OK):
-                ppcmds = [f'{checkpatch} -q --terse --no-summary --mailback --showfile']
+                spell = "--codespell" if can_codespell else ""
+                ppcmds = [f'{checkpatch} -q --terse --no-summary --mailback --showfile {spell}']
 
     # TODO: support for a whole-series check command, (pytest, etc)
     return ppcmds, scmds


### PR DESCRIPTION
This commit add --codespell to checkpatch.pl is the codespell package is install.

If b4 is installed with pipx you need to use --system-site-packages when calling install, otherwise it won't see the packages installed by your package manager.

@mricon this new feature was added since I forgot to run checkpatch.pl --codespell when sending the patch to the ML. I believed that b4 would do such check, but I was mistaken. What do you think about it?