### PR TITLE
ez: Correct the .git/filter-repo/already_ran path

### DIFF
--- a/src/b4/__init__.py
+++ b/src/b4/__init__.py
@@ -3725,6 +3725,16 @@ def git_branch_contains(gitdir: Optional[str], commit_id: str, checkall: bool = 
     return lines
 
 
+def git_get_git_dir(topdir: Optional[Union[str, Path]] = None):
+    gitargs = ['rev-parse', '--git-dir']
+    ecode, out = git_run_command(topdir, gitargs, logstderr=True)
+    if ecode > 0:
+        logger.critical('Unable to find git directory')
+        logger.critical(out.strip())
+        sys.exit(ecode)
+    return out.rstrip()
+
+
 def git_get_toplevel(path: Optional[str] = None) -> Optional[str]:
     topdir = None
     # Are we in a git tree and if so, what is our toplevel?

--- a/src/b4/ez.py
+++ b/src/b4/ez.py
@@ -124,13 +124,11 @@ def run_frf(frf: fr.RepoFilter) -> None:
     logger.debug('Running git-filter-repo...')
     frf.run()
     logger.debug('git-filter-repo complete')
-    gtl = b4.git_get_toplevel()
-    if isinstance(gtl, str):
-        # Remove .git/filter-repo/already_ran
-        already_ran = os.path.join(gtl, '.git', 'filter-repo', 'already_ran')
-        if os.path.exists(already_ran):
-            logger.debug('Removing %s', already_ran)
-            os.remove(already_ran)
+    # Remove .git/filter-repo/already_ran
+    already_ran = os.path.join(b4.git_get_git_dir(), 'filter-repo', 'already_ran')
+    if os.path.exists(already_ran):
+        logger.debug('Removing %s', already_ran)
+        os.remove(already_ran)
 
 
 def get_auth_configs() -> Tuple[str, str, str, str, str, str]:

--- a/src/b4/mbox.py
+++ b/src/b4/mbox.py
@@ -363,13 +363,7 @@ def make_am(msgs: List[EmailMessage], cmdargs: argparse.Namespace, msgid: str) -
         except RuntimeError:
             sys.exit(1)
 
-        gitargs = ['rev-parse', '--git-dir']
-        ecode, out = b4.git_run_command(topdir, gitargs, logstderr=True)
-        if ecode > 0:
-            logger.critical('Unable to find git directory')
-            logger.critical(out.strip())
-            sys.exit(ecode)
-        mmf = os.path.join(out.rstrip(), 'b4-cover')
+        mmf = os.path.join(b4.git_get_git_dir(), 'b4-cover')
         merge_template = DEFAULT_MERGE_TEMPLATE
         if config.get('shazam-merge-template'):
             # Try to load this template instead


### PR DESCRIPTION
The path to the ".git" directory may not be at the top level directory because it is a work tree, for example. Steal the logic to detect the real ".git" directory from mbox.